### PR TITLE
debian: add socat to runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,10 @@ Build-Depends:
 
 Package: split-gpg2
 Architecture: all
-Depends: ${misc:Depends}, python3-splitgpg2
+Depends:
+ python3-splitgpg2,
+ socat,
+ ${misc:Depends}
 Description: split-gpg2 for Qubes
   split-gpg2 allows you to run the gpg client in a different Qubes-Domain than
   the gpg-agent.


### PR DESCRIPTION
socat is required to run split-gpg2 correctly.
Fixes QubesOS/qubes-issues#9350
Fixes bd82ba1922ab