### PR TITLE
Recommends notification client and server

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,10 +25,12 @@ Architecture: any
 Depends:
  gnupg (>= 2.1.0~beta),
  zenity,
- libnotify-bin,
  python3-xdg,
  ${misc:Depends},
  ${python3:Depends},
+Recommends:
+ libnotify-bin,
+ notification-daemon,
 Description: Python package splitgpg2
  Python package splitgpg2
 

--- a/rpm_spec/split-gpg2.spec.in
+++ b/rpm_spec/split-gpg2.spec.in
@@ -19,7 +19,8 @@ Requires:       bash
 Requires:       gnupg2 >= 2.1.0
 Requires:       systemd
 Requires:       zenity
-Requires:       libnotify
+Recommends:     libnotify
+Recommends:     desktop-notification-daemon
 
 %description
 split-gpg2 allows you to run the gpg client in a different Qubes-Domain than


### PR DESCRIPTION
Recommends notification client and server

Fixes: https://github.com/QubesOS/qubes-issues/issues/9370

---

Calling notify send doesn't make it exit, which is fine for me:

```python3
subprocess.call(['notify-send', 'split-gpg2: {}'.format(msg)])
```

But notification server can be recommended for `verbose_notifications = True`.