### PR TITLE
Add prominent note to check key presences and passwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ or
 gpg-server-vm$ gpg --gen-key
 ```
 
+> [!NOTE]
+> * Ensure your key doesn't have a password set.
+> * Ensure you have subkeys for signing and, if needed, encryption.
+
 In dom0 enable the `split-gpg2-client` service in the client domain, for example via the command-line:
 
 ```shell


### PR DESCRIPTION
It might be obvious. But I had to spent way way to much time figuring this out.
Just oversaw those two things and never thought about them again. Especially since GPG doesn't give helpful log messages.