### PR TITLE
tests: adjust error handling

### DIFF
--- a/splitgpg2tests/tests.py
+++ b/splitgpg2tests/tests.py
@@ -424,6 +424,7 @@ user_pref("mail.identity.id1.smtpServer", "smtp1");
 user_pref("mail.identity.id1.compose_html", false);
 user_pref("datareporting.policy.dataSubmissionEnabled", false); // avoid message popups
 user_pref("app.donation.eoy.version.viewed", 100); // avoid message popups
+user_pref("mail.inappnotifications.enabled", false); // avoid message popups
 """
         imap_server = """
 user_pref("mail.server.server1.userName", "user");

--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -483,8 +483,7 @@ def receive_message(tb, signed=False, encrypted=False, attachment=None):
         # alternative way of opening 'message security'
         keyCombo('<Control><Alt>s')
         message_security = tb.app.child('Message Security - OpenPGP')
-    finally:
-        message_security = message_security.parent.parent
+    message_security = message_security.parent.parent
     try:
         if signed:
             message_security.child('Good Digital Signature')


### PR DESCRIPTION
Don't use 'finally' for code that shouldn't run if both normal and
fallback methods failed. Simply move it outside of the 'try' block.