### PR TITLE
Don't add working directory to Python's path

### DIFF
--- a/qubes.Gpg2.service
+++ b/qubes.Gpg2.service
@@ -7,4 +7,4 @@ for d in /etc "${XDG_CONFIG_HOME:-$HOME/.config}"; do
     fi
 done
 
-/usr/bin/python3 -m splitgpg2
+/usr/bin/python3 -P -m splitgpg2


### PR DESCRIPTION
When the service is called via qrexec this results in the home directory being in Pyhton's sys.path which means Python is looking for modules there too.