### PR TITLE
tests: use --faked-system-time on whonix instead of date -s

### DIFF
--- a/splitgpg2/test_termination.py
+++ b/splitgpg2/test_termination.py
@@ -35,6 +35,9 @@ class DidNotTerminate(AssertionError):
 # than the Unix socket we use for other tests (for example on close). So
 # instead start the service script directly.
 class TC_Termination(unittest.TestCase):
+    service_stdin: IO[bytes]
+    service_stdout: IO[bytes]
+
     @staticmethod
     def path_prepend(env: Dict[str, str], name: str, value: str) -> None:
         if name in env:

--- a/splitgpg2tests/tests.py
+++ b/splitgpg2tests/tests.py
@@ -32,18 +32,20 @@ class SplitGPGBase(qubes.tests.extra.ExtraTestCase):
         self.backend, self.frontend = self.create_vms(["backend", "frontend"])
 
         self.backend.start()
-        if self.backend.run('ls /etc/qubes-rpc/qubes.Gpg2', wait=True) != 0:
-            self.skipTest('gpg-split2 not installed')
+        if self.backend.run("ls /etc/qubes-rpc/qubes.Gpg2", wait=True) != 0:
+            self.skipTest("gpg-split2 not installed")
         # Whonix desynchronize time on purpose, so make sure the key is
         # generated in the past even when the frontend have clock few minutes
         #  into the future - otherwise new key may look as
         # generated in the future and be considered not yet valid
-        if 'whonix' in self.template:
+        if "whonix" in self.template:
             self.backend.run("date -s -10min", user="root", wait=True)
-        p = self.backend.run('mkdir -p -m 0700 .gnupg; gpg2 --gen-key --batch',
+        p = self.backend.run(
+            "mkdir -p -m 0700 .gnupg; gpg2 --gen-key --batch",
             passio_popen=True,
-            passio_stderr=True)
-        stdout, stderr = p.communicate('''
+            passio_stderr=True,
+        )
+        stdout, stderr = p.communicate("""
 Key-Type: RSA
 Key-Length: 1024
 Key-Usage: sign
@@ -55,189 +57,244 @@ Name-Email: user@localhost
 Expire-Date: 0
 %no-protection
 %commit
-        '''.encode())
+        """.encode())
         if p.returncode == 127:
-            self.skipTest('gpg2 not installed')
+            self.skipTest("gpg2 not installed")
         elif p.returncode != 0:
-            self.fail('key generation failed: {}{}'.format(stdout, stderr))
+            self.fail("key generation failed: {}{}".format(stdout, stderr))
 
-        cmd = 'gpg2 --with-colons --list-key user@localhost'
+        cmd = "gpg2 --with-colons --list-key user@localhost"
         p = self.backend.run(cmd, passio_popen=True, passio_stderr=True)
-        (stdout, stderr) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}{}'.format(cmd, stdout.decode(), stderr.decode()))
-        fpr = [l for l in stdout.splitlines() if l.startswith(b'fpr:')][0]
+        stdout, stderr = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}{}".format(cmd, stdout.decode(), stderr.decode()),
+        )
+        fpr = [l for l in stdout.splitlines() if l.startswith(b"fpr:")][0]
         fpr = fpr.decode().split(":")[9]
         # add signing subkey
         p = self.backend.run(
-            f"gpg2 --batch --passphrase "" --quick-add-key "
+            f"gpg2 --batch --passphrase "
+            " --quick-add-key "
             f"{fpr} rsa sign never",
             passio_popen=True,
-            passio_stderr=True)
+            passio_stderr=True,
+        )
         stdout, stderr = p.communicate()
         if p.returncode != 0:
-            self.fail('subkey generation failed: {}{}'.format(
-                      stdout, stderr))
-        if 'whonix' in self.template:
+            self.fail("subkey generation failed: {}{}".format(stdout, stderr))
+        if "whonix" in self.template:
             self.backend.run("date -s +10min", user="root", wait=True)
 
-        p = self.backend.run('mkdir -p .config/qubes-split-gpg2; cat > .config/qubes-split-gpg2/qubes-split-gpg2.conf', passio_popen=True)
-        p.communicate(
-                b'[DEFAULT]\n'
-                b'autoaccept = yes\n'
-                )
+        p = self.backend.run(
+            "mkdir -p .config/qubes-split-gpg2; cat > .config/qubes-split-gpg2/qubes-split-gpg2.conf",
+            passio_popen=True,
+        )
+        p.communicate(b"[DEFAULT]\n" b"autoaccept = yes\n")
 
-        self.frontend.features['service.split-gpg2-client'] = True
+        self.frontend.features["service.split-gpg2-client"] = True
 
         self.frontend.start()
 
-        self.qrexec_policy('qubes.Gpg2', self.frontend.name, '@default',
-            target=self.backend.name)
+        self.qrexec_policy(
+            "qubes.Gpg2",
+            self.frontend.name,
+            "@default",
+            target=self.backend.name,
+        )
 
         # import public key to the frontend domain
-        cmd = 'gpg2 -a --export user@localhost'
+        cmd = "gpg2 -a --export user@localhost"
         p = self.backend.run(cmd, passio_popen=True, passio_stderr=True)
-        (pubkey, stderr) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
-        cmd = 'gpg2 --import'
+        pubkey, stderr = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
+        cmd = "gpg2 --import"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (stdout, stderr) = p.communicate(pubkey)
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}{}'.format(cmd, stdout.decode(), stderr.decode()))
+        stdout, stderr = p.communicate(pubkey)
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}{}".format(cmd, stdout.decode(), stderr.decode()),
+        )
         # and set as trusted
-        cmd = 'gpg2 --with-colons --list-key user@localhost'
+        cmd = "gpg2 --with-colons --list-key user@localhost"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (stdout, stderr) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}{}'.format(cmd, stdout.decode(), stderr.decode()))
-        fpr = [l for l in stdout.splitlines() if l.startswith(b'fpr:')][0]
-        cmd = 'gpg2 --with-colons --import-ownertrust'
+        stdout, stderr = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}{}".format(cmd, stdout.decode(), stderr.decode()),
+        )
+        fpr = [l for l in stdout.splitlines() if l.startswith(b"fpr:")][0]
+        cmd = "gpg2 --with-colons --import-ownertrust"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (stdout, stderr) = p.communicate(
-            fpr.replace(b'fpr:::::::::', b'') + b'6:\n')
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}{}'.format(cmd, stdout.decode(), stderr.decode()))
+        stdout, stderr = p.communicate(
+            fpr.replace(b"fpr:::::::::", b"") + b"6:\n"
+        )
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}{}".format(cmd, stdout.decode(), stderr.decode()),
+        )
 
 
 class TC_00_Direct(SplitGPGBase):
     def test_000_version(self):
-        cmd = 'gpg2 --version'
+        cmd = "gpg2 --version"
         p = self.frontend.run(cmd, wait=True)
-        self.assertEqual(p, 0, '{} failed'.format(cmd))
+        self.assertEqual(p, 0, "{} failed".format(cmd))
 
     def test_010_list_keys(self):
-        cmd = 'gpg2 --list-keys'
+        cmd = "gpg2 --list-keys"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (keys, stderr) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
+        keys, stderr = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
         self.assertIn("Qubes test", keys.decode())
-        cmd = 'gpg2 --list-secret-keys'
+        cmd = "gpg2 --list-secret-keys"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (keys, stderr) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
+        keys, stderr = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
         self.assertIn("Qubes test", keys.decode())
 
     def test_020_export_secret_key_deny(self):
         # TODO check if backend really deny such operation, here it is denied
         # by the frontend
-        cmd = 'gpg2 -a --export-secret-keys user@localhost'
+        cmd = "gpg2 -a --export-secret-keys user@localhost"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         keys, stderr = p.communicate()
-        self.assertNotEqual(p.returncode, 0,
-            '{} succeeded unexpectedly: {}'.format(cmd, stderr.decode()))
-        self.assertEqual(keys.decode(), '')
+        self.assertNotEqual(
+            p.returncode,
+            0,
+            "{} succeeded unexpectedly: {}".format(cmd, stderr.decode()),
+        )
+        self.assertEqual(keys.decode(), "")
 
     def test_030_sign_verify(self):
         msg = "Test message"
-        cmd = 'gpg2 -a --sign -u user@localhost'
+        cmd = "gpg2 -a --sign -u user@localhost"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (signature, stderr) = p.communicate(msg.encode())
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
-        self.assertNotEqual('', signature.decode())
+        signature, stderr = p.communicate(msg.encode())
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
+        self.assertNotEqual("", signature.decode())
 
         cmd = "gpg2"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         decoded_msg, verification_result = p.communicate(signature)
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, verification_result.decode()))
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}".format(cmd, verification_result.decode()),
+        )
         self.assertEqual(decoded_msg.decode(), msg)
-        self.assertIn('\ngpg: Good signature from', verification_result.decode())
+        self.assertIn(
+            "\ngpg: Good signature from", verification_result.decode()
+        )
 
     def test_031_sign_verify_detached(self):
         msg = "Test message"
         self.frontend.run('echo "{}" > message'.format(msg), wait=True)
-        cmd = 'gpg2 --output=signature.asc -a -b --sign -u user@localhost message'
+        cmd = (
+            "gpg2 --output=signature.asc -a -b --sign -u user@localhost message"
+        )
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         stdout, stderr = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
 
-        cmd = 'gpg2 --verify signature.asc message'
+        cmd = "gpg2 --verify signature.asc message"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         decoded_msg, verification_result = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, verification_result.decode()))
-        self.assertEqual(decoded_msg.decode(), '')
-        self.assertIn('\ngpg: Good signature from', verification_result.decode())
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}".format(cmd, verification_result.decode()),
+        )
+        self.assertEqual(decoded_msg.decode(), "")
+        self.assertIn(
+            "\ngpg: Good signature from", verification_result.decode()
+        )
 
         # break the message and check again
         self.frontend.run('echo "{}" >> message'.format(msg), wait=True)
-        cmd = 'gpg2 --verify signature.asc message'
+        cmd = "gpg2 --verify signature.asc message"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         decoded_msg, verification_result = p.communicate()
-        self.assertNotEqual(p.returncode, 0,
-            '{} unexpecedly succeeded: {}'.format(cmd, verification_result.decode()))
-        self.assertEqual(decoded_msg.decode(), '')
-        self.assertIn('\ngpg: BAD signature from', verification_result.decode())
+        self.assertNotEqual(
+            p.returncode,
+            0,
+            "{} unexpecedly succeeded: {}".format(
+                cmd, verification_result.decode()
+            ),
+        )
+        self.assertEqual(decoded_msg.decode(), "")
+        self.assertIn("\ngpg: BAD signature from", verification_result.decode())
 
     def test_040_encrypt_decrypt(self):
         msg = "Test message"
-        cmd = 'gpg2 --trust-model tofu -a --encrypt -r user@localhost'
+        cmd = "gpg2 --trust-model tofu -a --encrypt -r user@localhost"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (encrypted, stderr) = p.communicate(msg.encode())
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
-        self.assertNotEqual('', encrypted.decode())
+        encrypted, stderr = p.communicate(msg.encode())
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
+        self.assertNotEqual("", encrypted.decode())
 
         cmd = "gpg2 --decrypt"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         decoded_msg, stderr = p.communicate(encrypted)
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
         self.assertEqual(decoded_msg.decode(), msg)
 
     def test_041_sign_encrypt_decrypt(self):
         msg = "Test message"
-        cmd = 'gpg2 --trust-model tofu -a --sign --encrypt -u user@localhost -r user@localhost'
+        cmd = "gpg2 --trust-model tofu -a --sign --encrypt -u user@localhost -r user@localhost"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
-        (encrypted, stderr) = p.communicate(msg.encode())
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, stderr.decode()))
-        self.assertNotEqual('', encrypted.decode())
+        encrypted, stderr = p.communicate(msg.encode())
+        self.assertEqual(
+            p.returncode, 0, "{} failed: {}".format(cmd, stderr.decode())
+        )
+        self.assertNotEqual("", encrypted.decode())
 
         cmd = "gpg2 --decrypt"
         p = self.frontend.run(cmd, passio_popen=True, passio_stderr=True)
         decoded_msg, verification_result = p.communicate(encrypted)
-        self.assertEqual(p.returncode, 0,
-            '{} failed: {}'.format(cmd, verification_result.decode()))
+        self.assertEqual(
+            p.returncode,
+            0,
+            "{} failed: {}".format(cmd, verification_result.decode()),
+        )
         self.assertEqual(decoded_msg.decode(), msg)
-        self.assertIn('\ngpg: Good signature from', verification_result.decode())
+        self.assertIn(
+            "\ngpg: Good signature from", verification_result.decode()
+        )
 
     def test_050_generate(self):
-        p = self.backend.run('cat >> .config/qubes-split-gpg2/qubes-split-gpg2.conf', passio_popen=True)
-        p.communicate(b'allow_keygen = yes\n')
+        p = self.backend.run(
+            "cat >> .config/qubes-split-gpg2/qubes-split-gpg2.conf",
+            passio_popen=True,
+        )
+        p.communicate(b"allow_keygen = yes\n")
 
         # see comment in setUp()
-        if 'whonix' in self.template:
+        if "whonix" in self.template:
             self.frontend.run("date -s -10min", user="root", wait=True)
 
-        p = self.frontend.run('mkdir -p -m 0700 .gnupg; gpg2 --gen-key --batch',
-                passio_popen=True)
-        p.communicate('''
+        p = self.frontend.run(
+            "mkdir -p -m 0700 .gnupg; gpg2 --gen-key --batch", passio_popen=True
+        )
+        p.communicate("""
 Key-Type: RSA
 Key-Length: 1024
 Key-Usage: sign
@@ -249,32 +306,32 @@ Name-Email: user2@localhost
 Expire-Date: 0
 %no-protection
 %commit
-        '''.encode())
-        assert p.returncode == 0, 'key generation failed'
+        """.encode())
+        assert p.returncode == 0, "key generation failed"
         # see comment in setUp()
-        if 'whonix' in self.template:
+        if "whonix" in self.template:
             self.frontend.run("date -s +10min", user="root", wait=True)
 
-        p = self.frontend.run('gpg2 --list-keys',
-            passio_popen=True)
-        (key_list, _) = p.communicate()
-        self.assertIn('user2@localhost', key_list.decode())
-        p = self.frontend.run('gpg2 --list-secret-keys',
-            passio_popen=True)
-        (key_list, _) = p.communicate()
-        self.assertIn('user2@localhost', key_list.decode())
+        p = self.frontend.run("gpg2 --list-keys", passio_popen=True)
+        key_list, _ = p.communicate()
+        self.assertIn("user2@localhost", key_list.decode())
+        p = self.frontend.run("gpg2 --list-secret-keys", passio_popen=True)
+        key_list, _ = p.communicate()
+        self.assertIn("user2@localhost", key_list.decode())
 
     def test_060_import_secret(self):
         # see comment in setUp()
-        if 'whonix' in self.template:
+        if "whonix" in self.template:
             self.frontend.run("date -s -10min", user="root", wait=True)
-        p = self.frontend.run('mkdir -p -m 0700 temp-gnupg; export GNUPGHOME=$HOME/temp-gnupg; '
-                'gpgconf --launch gpg-agent && '
-                'gpg2 --gen-key --batch && '
-                'gpg2 -a --export-secret-key user2@localhost && '
-                'gpgconf --kill gpg-agent',
-                passio_popen=True)
-        stdout, stderr = p.communicate('''
+        p = self.frontend.run(
+            "mkdir -p -m 0700 temp-gnupg; export GNUPGHOME=$HOME/temp-gnupg; "
+            "gpgconf --launch gpg-agent && "
+            "gpg2 --gen-key --batch && "
+            "gpg2 -a --export-secret-key user2@localhost && "
+            "gpgconf --kill gpg-agent",
+            passio_popen=True,
+        )
+        stdout, stderr = p.communicate("""
 Key-Type: RSA
 Key-Length: 1024
 Key-Usage: sign
@@ -286,64 +343,63 @@ Name-Email: user2@localhost
 Expire-Date: 0
 %no-protection
 %commit
-        '''.encode())
-        assert p.returncode == 0, 'key generation failed'
+        """.encode())
+        assert p.returncode == 0, "key generation failed"
         # see comment in setUp()
-        if 'whonix' in self.template:
+        if "whonix" in self.template:
             self.frontend.run("date -s +10min", user="root", wait=True)
 
-        p = self.frontend.run('gpg2 --list-keys',
-            passio_popen=True)
-        (key_list, _) = p.communicate()
-        self.assertNotIn('user2@localhost', key_list.decode())
-        p = self.frontend.run('gpg2 --list-secret-keys',
-            passio_popen=True)
-        (key_list, _) = p.communicate()
-        self.assertNotIn('user2@localhost', key_list.decode())
+        p = self.frontend.run("gpg2 --list-keys", passio_popen=True)
+        key_list, _ = p.communicate()
+        self.assertNotIn("user2@localhost", key_list.decode())
+        p = self.frontend.run("gpg2 --list-secret-keys", passio_popen=True)
+        key_list, _ = p.communicate()
+        self.assertNotIn("user2@localhost", key_list.decode())
 
-        p = self.frontend.run('gpg2 --import',
-            passio_popen=True)
+        p = self.frontend.run("gpg2 --import", passio_popen=True)
         p.communicate(stdout)
         # secret key import should be refused
         self.assertNotEqual(p.returncode, 0)
 
-        p = self.frontend.run('gpg2 --list-keys',
-            passio_popen=True)
-        (key_list, _) = p.communicate()
-        self.assertIn('user2@localhost', key_list.decode())
-        p = self.frontend.run('gpg2 --list-secret-keys',
-            passio_popen=True)
-        (key_list, _) = p.communicate()
-        self.assertNotIn('user2@localhost', key_list.decode())
+        p = self.frontend.run("gpg2 --list-keys", passio_popen=True)
+        key_list, _ = p.communicate()
+        self.assertIn("user2@localhost", key_list.decode())
+        p = self.frontend.run("gpg2 --list-secret-keys", passio_popen=True)
+        key_list, _ = p.communicate()
+        self.assertNotIn("user2@localhost", key_list.decode())
 
 
 class TC_10_Thunderbird(SplitGPGBase):
 
-    scriptpath = '/usr/share/split-gpg2-tests/test_thunderbird.py'
+    scriptpath = "/usr/share/split-gpg2-tests/test_thunderbird.py"
 
     def setUp(self):
-        if self.template.startswith('whonix-gw'):
-            self.skipTest('whonix-gw template not supported by this test')
+        if self.template.startswith("whonix-gw"):
+            self.skipTest("whonix-gw template not supported by this test")
         super(TC_10_Thunderbird, self).setUp()
-        self.frontend.run_service('qubes.WaitForSession', wait=True,
-            input='user')
-        if self.frontend.run('which thunderbird', wait=True) == 0:
-            self.tb_name = 'thunderbird'
-        elif self.frontend.run('which icedove', wait=True) == 0:
-            self.tb_name = 'icedove'
+        self.frontend.run_service(
+            "qubes.WaitForSession", wait=True, input="user"
+        )
+        if self.frontend.run("which thunderbird", wait=True) == 0:
+            self.tb_name = "thunderbird"
+        elif self.frontend.run("which icedove", wait=True) == 0:
+            self.tb_name = "icedove"
         else:
-            self.skipTest('Thunderbird not installed')
+            self.skipTest("Thunderbird not installed")
         # use dogtail 0.9.10 directly from git, until 0.9.10 gets packaged in
         # relevant distros; 0.9.9 have problems with handling unicode
         p = self.frontend.run(
-                'git clone -n https://gitlab.com/dogtail/dogtail.git && '
-                'cd dogtail && '
-                'git checkout 4d7923dcda92c2c44309d2a56b0bb616a1855155',
-                passio_popen=True, passio_stderr=True)
+            "git clone -n https://gitlab.com/dogtail/dogtail.git && "
+            "cd dogtail && "
+            "git checkout 4d7923dcda92c2c44309d2a56b0bb616a1855155",
+            passio_popen=True,
+            passio_stderr=True,
+        )
         stdout, stderr = p.communicate()
         if p.returncode:
             self.skipTest(
-                'dogtail installation failed: {}{}'.format(stdout, stderr))
+                "dogtail installation failed: {}{}".format(stdout, stderr)
+            )
 
         # if self.frontend.run(
         #         'python -c \'import dogtail,sys;'
@@ -351,49 +407,63 @@ class TC_10_Thunderbird(SplitGPGBase):
         #         != 0:
         #     self.skipTest('dogtail >= 0.9.0 testing framework not installed')
 
-        p = self.frontend.run('gsettings set org.gnome.desktop.interface '
-                              'toolkit-accessibility true', wait=True)
-        assert p == 0, 'Failed to enable accessibility toolkit'
-        if self.frontend.run(
-                'ls {}'.format(self.scriptpath), wait=True):
-            self.skipTest('split-gpg2-tests package not installed')
+        p = self.frontend.run(
+            "gsettings set org.gnome.desktop.interface "
+            "toolkit-accessibility true",
+            wait=True,
+        )
+        assert p == 0, "Failed to enable accessibility toolkit"
+        if self.frontend.run("ls {}".format(self.scriptpath), wait=True):
+            self.skipTest("split-gpg2-tests package not installed")
 
         # run as root to not deal with /var/mail permission issues
-        self.frontend.run(
-            'mkdir -p Mail/new Mail/cur Mail/tmp',
-            wait=True)
+        self.frontend.run("mkdir -p Mail/new Mail/cur Mail/tmp", wait=True)
 
         # SMTP configuration
         self.smtp_server = self.frontend.run(
-            'aiosmtpd -n -c aiosmtpd.handlers.Mailbox /home/user/Mail',
-            passio_popen=True)
+            "aiosmtpd -n -c aiosmtpd.handlers.Mailbox /home/user/Mail",
+            passio_popen=True,
+        )
 
         # IMAP configuration
         self.imap_pw = "pass"
-        if self.frontend.run("grep -rq mail_driver /etc/dovecot/", wait=True) == 0:
+        if (
+            self.frontend.run("grep -rq mail_driver /etc/dovecot/", wait=True)
+            == 0
+        ):
             self.frontend.run(
                 'echo "mail_driver = maildir\nmail_path = ~/Mail\nmail_inbox_path = ~/Mail\nuserdb static {\n driver = passwd\n}\npassdb static {\n driver = static\n password=pass\n}" |\
-                    tee /etc/dovecot/conf.d/100-mail.conf', wait=True, user="root")
+                    tee /etc/dovecot/conf.d/100-mail.conf',
+                wait=True,
+                user="root",
+            )
         else:
             self.frontend.run(
                 'echo "mail_location=maildir:~/Mail\nuserdb {\n driver = passwd\n}\npassdb $db_name {\n driver = static\n args = password=pass\n}" |\
-                    tee /etc/dovecot/conf.d/100-mail.conf', wait=True, user="root")
+                    tee /etc/dovecot/conf.d/100-mail.conf',
+                wait=True,
+                user="root",
+            )
         self.frontend.run(
             "sed -i 's/^!include/#\\0/' /etc/dovecot/conf.d/10-auth.conf",
-            wait=True, user="root")
-        self.frontend.run('systemctl restart dovecot',
-            wait=True, user="root")
+            wait=True,
+            user="root",
+        )
+        self.frontend.run("systemctl restart dovecot", wait=True, user="root")
 
         self.setup_tb_profile(setup_openpgp=True)
 
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 '
-            'python3 {} --tbname={} --profile {} --imap_pw {} setup 2>&1'.format(
-                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        assert p.returncode == 0, 'Thunderbird setup failed: {}'.format(
-            stdout.decode('ascii', 'ignore'))
+            "PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 "
+            "python3 {} --tbname={} --profile {} --imap_pw {} setup 2>&1".format(
+                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw
+            ),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        assert p.returncode == 0, "Thunderbird setup failed: {}".format(
+            stdout.decode("ascii", "ignore")
+        )
 
     def tearDown(self):
         self.smtp_server.terminate()
@@ -401,12 +471,12 @@ class TC_10_Thunderbird(SplitGPGBase):
         super(TC_10_Thunderbird, self).tearDown()
 
     def get_key_fpr(self):
-        cmd = 'gpg2 -K --with-colons'
+        cmd = "gpg2 -K --with-colons"
         p = self.frontend.run(cmd, passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0, 'Failed to determin key id')
-        keyid = stdout.decode('utf-8').split('\n')[1]
-        keyid = keyid.split(':')[9]
+        stdout, _ = p.communicate()
+        self.assertEqual(p.returncode, 0, "Failed to determin key id")
+        keyid = stdout.decode("utf-8").split("\n")[1]
+        keyid = keyid.split(":")[9]
         keyid = keyid[-16:]
         return keyid
 
@@ -466,74 +536,101 @@ user_pref("mail.identity.id1.sign_mail", false);
         if setup_openpgp:
             user_js += open_pgp + user_account_pgp
 
-        self.frontend.run('mkdir -p {}'.format(self.profile_dir),
-                          user='user', wait=True)
-        p = self.frontend.run('cat > ' + user_js_path,
-                          user='user', passio_popen=True)
-        (stdout, _) = p.communicate(user_js.encode())
-        assert p.returncode == 0, 'Thunderbird profile configuration failed: {}'\
-            .format(stdout.decode('ascii', 'ignore'))
+        self.frontend.run(
+            "mkdir -p {}".format(self.profile_dir), user="user", wait=True
+        )
+        p = self.frontend.run(
+            "cat > " + user_js_path, user="user", passio_popen=True
+        )
+        stdout, _ = p.communicate(user_js.encode())
+        assert (
+            p.returncode == 0
+        ), "Thunderbird profile configuration failed: {}".format(
+            stdout.decode("ascii", "ignore")
+        )
 
     def test_000_send_receive_default(self):
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 '
-            'python3 {} --tbname={} --profile {} --imap_pw {} send_receive '
-            '--encrypted --signed 2>&1'.format(
-                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            'Thunderbird send/receive failed: {}'.format(
-                stdout.decode('ascii', 'ignore')))
+            "PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 "
+            "python3 {} --tbname={} --profile {} --imap_pw {} send_receive "
+            "--encrypted --signed 2>&1".format(
+                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw
+            ),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "Thunderbird send/receive failed: {}".format(
+                stdout.decode("ascii", "ignore")
+            ),
+        )
 
     def test_010_send_receive_inline_signed_only(self):
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 '
-            'python3 {} --tbname={} --profile {} --imap_pw {} send_receive '
-            '--encrypted --signed --inline 2>&1'.format(
-                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            'Thunderbird send/receive failed: {}'.format(
-                stdout.decode('ascii', 'ignore')))
+            "PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 "
+            "python3 {} --tbname={} --profile {} --imap_pw {} send_receive "
+            "--encrypted --signed --inline 2>&1".format(
+                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw
+            ),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "Thunderbird send/receive failed: {}".format(
+                stdout.decode("ascii", "ignore")
+            ),
+        )
 
     def test_020_send_receive_inline_with_attachment(self):
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 '
-            'python3 {} --tbname={} --profile {} --imap_pw {} send_receive '
-            '--encrypted --signed --inline --with-attachment 2>&1'.format(
-                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            'Thunderbird send/receive failed: {}'.format(
-                stdout.decode('ascii', 'ignore')))
+            "PYTHONPATH=$HOME/dogtail LC_ALL=C.UTF-8 "
+            "python3 {} --tbname={} --profile {} --imap_pw {} send_receive "
+            "--encrypted --signed --inline --with-attachment 2>&1".format(
+                self.scriptpath, self.tb_name, self.profile_dir, self.imap_pw
+            ),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "Thunderbird send/receive failed: {}".format(
+                stdout.decode("ascii", "ignore")
+            ),
+        )
 
 
 class TC_20_Evolution(SplitGPGBase):
 
-    scriptpath = '/usr/share/split-gpg2-tests/test_evolution.py'
+    scriptpath = "/usr/share/split-gpg2-tests/test_evolution.py"
 
     def setUp(self):
-        if self.template.startswith('whonix-gw'):
-            self.skipTest('whonix-gw template not supported by this test')
+        if self.template.startswith("whonix-gw"):
+            self.skipTest("whonix-gw template not supported by this test")
         super(TC_20_Evolution, self).setUp()
-        self.frontend.run_service('qubes.WaitForSession', wait=True,
-            input='user')
-        if self.frontend.run('which evolution', wait=True) != 0:
-            self.skipTest('Evolution not installed')
+        self.frontend.run_service(
+            "qubes.WaitForSession", wait=True, input="user"
+        )
+        if self.frontend.run("which evolution", wait=True) != 0:
+            self.skipTest("Evolution not installed")
         # use dogtail 0.9.10 directly from git, until 0.9.10 gets packaged in
         # relevant distros; 0.9.9 have problems with handling unicode
         p = self.frontend.run(
-                'git clone -n https://gitlab.com/dogtail/dogtail.git && '
-                'cd dogtail && '
-                'git checkout 4d7923dcda92c2c44309d2a56b0bb616a1855155',
-                passio_popen=True, passio_stderr=True)
+            "git clone -n https://gitlab.com/dogtail/dogtail.git && "
+            "cd dogtail && "
+            "git checkout 4d7923dcda92c2c44309d2a56b0bb616a1855155",
+            passio_popen=True,
+            passio_stderr=True,
+        )
         stdout, stderr = p.communicate()
         if p.returncode:
             self.skipTest(
-                'dogtail installation failed: {}{}'.format(stdout, stderr))
+                "dogtail installation failed: {}{}".format(stdout, stderr)
+            )
 
         # if self.frontend.run(
         #         'python -c \'import dogtail,sys;'
@@ -541,28 +638,32 @@ class TC_20_Evolution(SplitGPGBase):
         #         != 0:
         #     self.skipTest('dogtail >= 0.9.0 testing framework not installed')
 
-        p = self.frontend.run('gsettings set org.gnome.desktop.interface '
-                              'toolkit-accessibility true', wait=True)
-        assert p == 0, 'Failed to enable accessibility toolkit'
-        if self.frontend.run(
-                'ls {}'.format(self.scriptpath), wait=True):
-            self.skipTest('split-gpg2-tests package not installed')
+        p = self.frontend.run(
+            "gsettings set org.gnome.desktop.interface "
+            "toolkit-accessibility true",
+            wait=True,
+        )
+        assert p == 0, "Failed to enable accessibility toolkit"
+        if self.frontend.run("ls {}".format(self.scriptpath), wait=True):
+            self.skipTest("split-gpg2-tests package not installed")
 
         # run as root to not deal with /var/mail permission issues
-        self.frontend.run(
-            'mkdir -p Mail/new Mail/cur Mail/tmp',
-            wait=True)
+        self.frontend.run("mkdir -p Mail/new Mail/cur Mail/tmp", wait=True)
         self.smtp_server = self.frontend.run(
-            'aiosmtpd -n -c aiosmtpd.handlers.Mailbox /home/user/Mail',
-            passio_popen=True)
+            "aiosmtpd -n -c aiosmtpd.handlers.Mailbox /home/user/Mail",
+            passio_popen=True,
+        )
 
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail python3 {} setup 2>&1'.format(
-                self.scriptpath),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        assert p.returncode == 0, 'Evolution setup failed: {}'.format(
-            stdout.decode('ascii', 'ignore'))
+            "PYTHONPATH=$HOME/dogtail python3 {} setup 2>&1".format(
+                self.scriptpath
+            ),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        assert p.returncode == 0, "Evolution setup failed: {}".format(
+            stdout.decode("ascii", "ignore")
+        )
 
     def tearDown(self):
         self.smtp_server.terminate()
@@ -571,41 +672,52 @@ class TC_20_Evolution(SplitGPGBase):
 
     def test_000_send_receive_signed_encrypted(self):
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail python3 {} send_receive '
-            '--encrypted --signed 2>&1'.format(
-                self.scriptpath),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            'Evolution send/receive failed: {}'.format(
-                stdout.decode('ascii', 'ignore')))
+            "PYTHONPATH=$HOME/dogtail python3 {} send_receive "
+            "--encrypted --signed 2>&1".format(self.scriptpath),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "Evolution send/receive failed: {}".format(
+                stdout.decode("ascii", "ignore")
+            ),
+        )
 
     def test_010_send_receive_signed_only(self):
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail python3 {} send_receive '
-            '--encrypted --signed 2>&1'.format(
-                self.scriptpath),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            'Evolution send/receive failed: {}'.format(
-                stdout.decode('ascii', 'ignore')))
+            "PYTHONPATH=$HOME/dogtail python3 {} send_receive "
+            "--encrypted --signed 2>&1".format(self.scriptpath),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "Evolution send/receive failed: {}".format(
+                stdout.decode("ascii", "ignore")
+            ),
+        )
 
-    @unittest.skip('handling attachments not done')
+    @unittest.skip("handling attachments not done")
     def test_020_send_receive_with_attachment(self):
         p = self.frontend.run(
-            'PYTHONPATH=$HOME/dogtail python3 {} send_receive '
-            '--encrypted --signed --with-attachment 2>&1'.format(
-                self.scriptpath),
-            passio_popen=True)
-        (stdout, _) = p.communicate()
-        self.assertEqual(p.returncode, 0,
-            'Evolution send/receive failed: {}'.format(
-                stdout.decode('ascii', 'ignore')))
+            "PYTHONPATH=$HOME/dogtail python3 {} send_receive "
+            "--encrypted --signed --with-attachment 2>&1".format(
+                self.scriptpath
+            ),
+            passio_popen=True,
+        )
+        stdout, _ = p.communicate()
+        self.assertEqual(
+            p.returncode,
+            0,
+            "Evolution send/receive failed: {}".format(
+                stdout.decode("ascii", "ignore")
+            ),
+        )
+
 
 def list_tests():
-    return (
-        TC_00_Direct,
-        TC_10_Thunderbird,
-        TC_20_Evolution
-    )
+    return (TC_00_Direct, TC_10_Thunderbird, TC_20_Evolution)

--- a/splitgpg2tests/tests.py
+++ b/splitgpg2tests/tests.py
@@ -20,6 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
 #
+import time
 import unittest
 
 import qubes.tests.extra
@@ -38,10 +39,11 @@ class SplitGPGBase(qubes.tests.extra.ExtraTestCase):
         # generated in the past even when the frontend have clock few minutes
         #  into the future - otherwise new key may look as
         # generated in the future and be considered not yet valid
+        gpg_time_opts = ""
         if "whonix" in self.template:
-            self.backend.run("date -s -10min", user="root", wait=True)
+            gpg_time_opts = f"--faked-system-time {int(time.time()) - 600}!"
         p = self.backend.run(
-            "mkdir -p -m 0700 .gnupg; gpg2 --gen-key --batch",
+            f"mkdir -p -m 0700 .gnupg; gpg2 {gpg_time_opts} --gen-key --batch",
             passio_popen=True,
             passio_stderr=True,
         )
@@ -73,9 +75,12 @@ Expire-Date: 0
         )
         fpr = [l for l in stdout.splitlines() if l.startswith(b"fpr:")][0]
         fpr = fpr.decode().split(":")[9]
+        if "whonix" in self.template:
+            # make it strictly later than the main key
+            gpg_time_opts = f"--faked-system-time {int(time.time()) - 599}!"
         # add signing subkey
         p = self.backend.run(
-            f"gpg2 --batch --passphrase "
+            f"gpg2 {gpg_time_opts} --batch --passphrase "
             " --quick-add-key "
             f"{fpr} rsa sign never",
             passio_popen=True,
@@ -84,8 +89,6 @@ Expire-Date: 0
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             self.fail("subkey generation failed: {}{}".format(stdout, stderr))
-        if "whonix" in self.template:
-            self.backend.run("date -s +10min", user="root", wait=True)
 
         p = self.backend.run(
             "mkdir -p .config/qubes-split-gpg2; cat > .config/qubes-split-gpg2/qubes-split-gpg2.conf",
@@ -288,11 +291,13 @@ class TC_00_Direct(SplitGPGBase):
         p.communicate(b"allow_keygen = yes\n")
 
         # see comment in setUp()
+        gpg_time_opts = ""
         if "whonix" in self.template:
-            self.frontend.run("date -s -10min", user="root", wait=True)
+            gpg_time_opts = f"--faked-system-time {int(time.time()) - 600}!"
 
         p = self.frontend.run(
-            "mkdir -p -m 0700 .gnupg; gpg2 --gen-key --batch", passio_popen=True
+            f"mkdir -p -m 0700 .gnupg; gpg2 {gpg_time_opts} --gen-key --batch",
+            passio_popen=True
         )
         p.communicate("""
 Key-Type: RSA
@@ -308,9 +313,6 @@ Expire-Date: 0
 %commit
         """.encode())
         assert p.returncode == 0, "key generation failed"
-        # see comment in setUp()
-        if "whonix" in self.template:
-            self.frontend.run("date -s +10min", user="root", wait=True)
 
         p = self.frontend.run("gpg2 --list-keys", passio_popen=True)
         key_list, _ = p.communicate()
@@ -321,12 +323,13 @@ Expire-Date: 0
 
     def test_060_import_secret(self):
         # see comment in setUp()
+        gpg_time_opts = ""
         if "whonix" in self.template:
-            self.frontend.run("date -s -10min", user="root", wait=True)
+            gpg_time_opts = f"--faked-system-time {int(time.time()) - 600}!"
         p = self.frontend.run(
             "mkdir -p -m 0700 temp-gnupg; export GNUPGHOME=$HOME/temp-gnupg; "
             "gpgconf --launch gpg-agent && "
-            "gpg2 --gen-key --batch && "
+            f"gpg2 {gpg_time_opts} --gen-key --batch && "
             "gpg2 -a --export-secret-key user2@localhost && "
             "gpgconf --kill gpg-agent",
             passio_popen=True,
@@ -345,9 +348,6 @@ Expire-Date: 0
 %commit
         """.encode())
         assert p.returncode == 0, "key generation failed"
-        # see comment in setUp()
-        if "whonix" in self.template:
-            self.frontend.run("date -s +10min", user="root", wait=True)
 
         p = self.frontend.run("gpg2 --list-keys", passio_popen=True)
         key_list, _ = p.communicate()


### PR DESCRIPTION
Changing system time for the key generation time is unreliable - it's
possible that sdwdate will change it back in the meantime. To avoid
dealing with time drift between frontend and backend, generate key with
timestamp in the past using gpg2 --faked-system-time instead.
  